### PR TITLE
[hotfix] Add error handling to repo:get-resource

### DIFF
--- a/modules/get-icon.xql
+++ b/modules/get-icon.xql
@@ -2,11 +2,19 @@ xquery version "3.1";
 
 
 let $repo := request:get-parameter("package", ())
-let $iconSvg := repo:get-resource($repo, "icon.svg")
+let $iconSvg := 
+    (: TODO: Replace try-catch expression with repo:resource-available 
+     : when https://github.com/eXist-db/exist/issues/3904 is resolved 
+     :)
+    try { repo:get-resource($app, "icon.svg") } catch * { () }
 return
 if(exists($iconSvg))
 then response:stream-binary($iconSvg, "image/svg+xml", ())
 else (
-	let $icon := repo:get-resource($repo, "icon.png")
+	let $icon := 
+        (: TODO: Replace try-catch expression with repo:resource-available 
+         : when https://github.com/eXist-db/exist/issues/3904 is resolved 
+         :)
+        try { repo:get-resource($repo, "icon.png") } catch * { () }
     return response:stream-binary($icon, "image/png", ())
 )

--- a/modules/packages.xqm
+++ b/modules/packages.xqm
@@ -164,8 +164,11 @@ declare function packages:installed-apps($type as xs:string) as element(repo-app
 
 
                 let $icon :=
-                    let $iconRes := repo:get-resource($app, "icon.png")
-                    let $iconSvg := repo:get-resource($app, "icon.svg")
+                    (: TODO: Replace try-catch expressions below with repo:resource-available 
+                     : when https://github.com/eXist-db/exist/issues/3904 is resolved 
+                     :)
+                    let $iconRes := try { repo:get-resource($app, "icon.png") } catch * { () }
+                    let $iconSvg := try { repo:get-resource($app, "icon.svg") } catch * { () }
                     let $hasIcon := exists($iconRes) or exists($iconSvg)
                     return
                         $hasIcon


### PR DESCRIPTION
A quick fix to https://github.com/eXist-db/existdb-packageservice/issues/19.

We should replace the workaround in this PR with the forthcoming `repo:resource-available` function when https://github.com/eXist-db/exist/issues/3904 is resolved.