### PR TITLE
[fix] handle exceptions in get-package-meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+.DS_Store

--- a/modules/packages.xqm
+++ b/modules/packages.xqm
@@ -272,11 +272,16 @@ declare function packages:get-package-meta($app as xs:string, $name as xs:string
         => util:binary-to-string() 
         => parse-xml()
     } catch * {
-        document {
-            <meta xmlns="http://exist-db.org/xquery/repo">
-                <description>Invalid repo descriptor for app {$app}</description>
-            </meta>
-        }
+        let $message := "The " || $name || " package metadata document could not be found for the package " || $app
+        return
+            (
+                util:log("WARN", $message),
+                document {
+                    <meta xmlns="http://exist-db.org/xquery/repo">
+                        <description>{$message}</description>
+                    </meta>
+                }
+            )
     }
 };
 

--- a/modules/packages.xqm
+++ b/modules/packages.xqm
@@ -264,15 +264,19 @@ declare function packages:scan-repo($callback as function(xs:string, element(), 
 };
 
 (: should be private but there seems to be a bug :)
-declare function packages:get-package-meta($app as xs:string, $name as xs:string) as element(repo:meta) {
+(: NOTE: The present try-catch fallback assumes this function returns repo.xml files, but it
+ : also returns expath-pkg.xml files; see packages:scan-repo() above. :)
+declare function packages:get-package-meta($app as xs:string, $name as xs:string) as document-node() {
     try {
         repo:get-resource($app, $name)
         => util:binary-to-string() 
         => parse-xml()
     } catch * {
-        <meta xmlns="http://exist-db.org/xquery/repo">
-            <description>Invalid repo descriptor for app {$app}</description>
-        </meta>
+        document {
+            <meta xmlns="http://exist-db.org/xquery/repo">
+                <description>Invalid repo descriptor for app {$app}</description>
+            </meta>
+        }
     }
 };
 

--- a/modules/packages.xqm
+++ b/modules/packages.xqm
@@ -264,22 +264,16 @@ declare function packages:scan-repo($callback as function(xs:string, element(), 
 };
 
 (: should be private but there seems to be a bug :)
-declare function packages:get-package-meta($app as xs:string, $name as xs:string) {
-    let $data :=
-        let $meta := repo:get-resource($app, $name)
-        return
-            if (exists($meta)) then util:binary-to-string($meta) else ()
-    return
-        if (exists($data)) then
-            try {
-                parse-xml($data)
-            } catch * {
-                <meta xmlns="http://exist-db.org/xquery/repo">
-                    <description>Invalid repo descriptor for app {$app}</description>
-                </meta>
-            }
-        else
-            ()
+declare function packages:get-package-meta($app as xs:string, $name as xs:string) as element(repo:meta) {
+    try {
+        repo:get-resource($app, $name)
+        => util:binary-to-string() 
+        => parse-xml()
+    } catch * {
+        <meta xmlns="http://exist-db.org/xquery/repo">
+            <description>Invalid repo descriptor for app {$app}</description>
+        </meta>
+    }
 };
 
 (: should be private but there seems to be a bug :)


### PR DESCRIPTION
- repo:get-resource throws an error if the repo.xml cannot be found
- simplify function logic to always return a repo:meta element
  If any problem occurs this will have
  "Invalid repo descriptor for app {$app}" as its contents