### PR TITLE
Update for packages that only have icon.png

### DIFF
--- a/modules/get-icon.xql
+++ b/modules/get-icon.xql
@@ -1,20 +1,10 @@
 xquery version "3.1";
 
-
 let $repo := request:get-parameter("package", ())
-let $iconSvg := 
-    (: TODO: Replace try-catch expression with repo:resource-available 
-     : when https://github.com/eXist-db/exist/issues/3904 is resolved 
-     :)
-    try { repo:get-resource($repo, "icon.svg") } catch * { () }
 return
-if(exists($iconSvg))
-then response:stream-binary($iconSvg, "image/svg+xml", ())
-else (
-	let $icon := 
-        (: TODO: Replace try-catch expression with repo:resource-available 
-         : when https://github.com/eXist-db/exist/issues/3904 is resolved 
-         :)
-        try { repo:get-resource($repo, "icon.png") } catch * { () }
-    return response:stream-binary($icon, "image/png", ())
-)
+    try {
+        response:stream-binary(repo:get-resource($repo, "icon.svg"), "image/svg+xml", ())
+    }
+    catch * {
+        response:stream-binary(repo:get-resource($repo, "icon.png"), "image/png", ())
+    }


### PR DESCRIPTION
repo:get-resource($repo, "icon.svg") errors out when the icon does not exist. This means that `if (empty($icon)) then ... else ...` is never triggered and thus icon.png is never attempted. By using try/catch this now works properly and icon.png fallback works.