### PR TITLE
load packages over a secure connection

### DIFF
--- a/configuration.xml
+++ b/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
     <repositories>
-        <repository active="true" default="true">http://exist-db.org/exist/apps/public-repo</repository>
+        <repository active="true" default="true">https://exist-db.org/exist/apps/public-repo</repository>
     </repositories>
     <readonly>
         <package>http://exist-db.org/apps/existdb-packageservice</package>


### PR DESCRIPTION
Now that https://github.com/eXist-db/public-repo/issues/74 is fixed we should
use the opportunity to make package downloads a little bit safer.