### PR TITLE
Ensure packages with updates are sorted first

### DIFF
--- a/modules/remote-packages.xql
+++ b/modules/remote-packages.xql
@@ -28,7 +28,10 @@ declare option output:media-type "text/html";
                                 $config:DEFAULT-REPO || "/public/" || $pkg/icon[1]
                             else
                                 $path || "/resources/images/package.png"
-            order by $pkg/@available, lower-case($pkg/title)
+            let $update-available := exists($pkg/@installed)
+            (: Ensure updates to installed packages appear at the top of the list, before other packages :)
+            let $update-available-sort := if ($update-available) then "A" else "B"
+            order by $update-available-sort, $pkg/@available, lower-case($pkg/title)
             return
                 <repo-app url="{data($pkg/name)}"
                           abbrev="{data($pkg/abbrev)}"
@@ -36,24 +39,19 @@ declare option output:media-type "text/html";
                           version="{data($pkg/version)}"
                           status="available">
                     {
-                        if(exists($pkg/@installed)) then
-                        attribute{"class"}{"update"}
-                        else()
+                        if ($update-available) then
+                            (
+                                attribute class { "update" },
+                                <repo-installed>{data($pkg/@installed)}</repo-installed>,
+                                <repo-available>{data($pkg/@available)}</repo-available>
+                            )
+                        else
+                            ()
                     }
                     <repo-icon src="{$icon}">&#160;</repo-icon>
                     <repo-type>{data($pkg/type)}</repo-type>
                     <repo-title>{data($pkg/title)}</repo-title>
                     <repo-version>{data($pkg/version)}</repo-version>
-                    {
-                        if(exists($pkg/@installed)) then
-                            <repo-installed>{data($pkg/@installed)}</repo-installed>
-                        else ()
-                    }
-                    {
-                        if(exists($pkg/@available)) then
-                            <repo-available>{data($pkg/@available)}</repo-available>
-                        else()
-                    }
                     <repo-name>{data($pkg/name)}</repo-name>
                     <repo-description>{data($pkg/description)}</repo-description>
 


### PR DESCRIPTION
I seem to recall that packages with available updates would appear clustered at the top of the listing of "Available" packages in Dashboard's Package Manager.

But today, running eXist 7.0.0-SNAPSHOT, I noticed that packages with available updates were sorted at the bottom of the list (notice that eXide is at the bottom here):

> <img width="1136" alt="Screenshot 2023-05-13 at 13 24 49@2x" src="https://github.com/eXist-db/existdb-packageservice/assets/59118/f9f25952-b573-48d3-96fe-cb4d479125db">

Before this PR, it appears that packages were always sorted alphabetically, without regard to available update status. (So I don't know why they previously were clustered at the top of the list!?)

This PR applies sorting, so that the service that Dashboard calls returns the packages in the expected order - with the packages with available updates clustered at the top of the listing.