### PR TITLE
[bugfix] Updates should appear first in the list of Available Packages

### DIFF
--- a/modules/remote-packages.xql
+++ b/modules/remote-packages.xql
@@ -28,10 +28,8 @@ declare option output:media-type "text/html";
                                 $config:DEFAULT-REPO || "/public/" || $pkg/icon[1]
                             else
                                 $path || "/resources/images/package.png"
-            let $update-available := exists($pkg/@installed)
             (: Ensure updates to installed packages appear at the top of the list, before other packages :)
-            let $update-available-sort := if ($update-available) then "A" else "B"
-            order by $update-available-sort, $pkg/@available, lower-case($pkg/title)
+            order by $pkg/@available empty greatest, lower-case($pkg/title)
             return
                 <repo-app url="{data($pkg/name)}"
                           abbrev="{data($pkg/abbrev)}"
@@ -39,7 +37,7 @@ declare option output:media-type "text/html";
                           version="{data($pkg/version)}"
                           status="available">
                     {
-                        if ($update-available) then
+                        if (exists($pkg/@installed)) then
                             (
                                 attribute class { "update" },
                                 <repo-installed>{data($pkg/@installed)}</repo-installed>,


### PR DESCRIPTION
[bugfix] Since Feb 2023 (commit https://github.com/eXist-db/exist/commit/395893952d59f9d788129da324029808d282bd8f) the default ordering in eXist-db changed to match that of Saxon and BaseX, it looks like the Package Service was never updated for that. This patch ensures that package updates always appear first in the list of available updates. This is compatible with eXist-db 6.x.x and 7.0.0-SNAPSHOT

----
The following XQuery shows the problem in a nutshell:

```xquery
let $apps := (
  <app available-update="1.1">a</app>,
  <app>b</app>,
  <app available-update="1.2">c</app>,
  <app>d</app>
)
for $app in $apps
order by $app/@available-update empty greatest
return
    $app
```

Change `empty greatest` to `empty least` which is the default in eXist-db after Feb 2023.